### PR TITLE
RMIO-84 Fix StreamWithTimeoutDecoratorTest tests that are broken in .NET (Backport 2.1)

### DIFF
--- a/UnitTests/StreamWithTimeoutDecoratorTest.cs
+++ b/UnitTests/StreamWithTimeoutDecoratorTest.cs
@@ -355,7 +355,7 @@ namespace Remotion.IO.UnitTests
       var decoratedStream = new StreamWithTimeoutDecorator (stream);
 
       Assert.That (
-          () => decoratedStream.Write (new byte[10], 22, 33),
+          () => decoratedStream.Write (new byte[10], 0, 10),
           Throws.InstanceOf<TimeoutException>());
     }
 
@@ -425,7 +425,7 @@ namespace Remotion.IO.UnitTests
       var decoratedStream = new StreamWithTimeoutDecorator (stream);
 
       Assert.That (
-          () => decoratedStream.Read (new byte[10], 22, 33),
+          () => decoratedStream.Read (new byte[10], 0, 10),
           Throws.InstanceOf<TimeoutException>());
     }
   }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RMIO-84

backport of #15 